### PR TITLE
Fix Doctrine platform check

### DIFF
--- a/Classes/Domain/Repository/FileRepository.php
+++ b/Classes/Domain/Repository/FileRepository.php
@@ -73,7 +73,7 @@ class FileRepository
         if ($platform instanceof DoctrineMySQLPlatform) {
             return 'mysql';
         }
-        if ($platform instanceof DoctrinePostgreSqlPlatform) {
+        if ($platform instanceof DoctrinePostgreSQLPlatform) {
             return 'postgresql';
         }
         if ($platform instanceof DoctrineSQLitePlatform) {

--- a/Tests/Unit/Rendering/TwitchRendererTest.php
+++ b/Tests/Unit/Rendering/TwitchRendererTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ayacoo\Tiktok\Tests\Unit\Rendering;
+namespace Ayacoo\Twitch\Tests\Unit\Rendering;
 
 use Ayacoo\Twitch\Event\ModifyTwitchOutputEvent;
 use Ayacoo\Twitch\Helper\TwitchHelper;


### PR DESCRIPTION
## Summary
- fix Doctrine PostgreSQL platform check
- correct namespace for TwitchRenderer tests

## Testing
- `composer -n ci:php:lint` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844607afd8c832996ecbb24a7ee92a5